### PR TITLE
Fix typo in `fn watch_thread` doc comment

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -87,7 +87,7 @@ impl<Tz> Scheduler<Tz> where
     <Tz as chrono::TimeZone>::Offset: Send {
 
     /// Start a background thread to call [Scheduler::run_pending()] with the specified frequency.
-    /// The resulting thread fill end cleanly if the returned [ScheduleHandle] is dropped.
+    /// The resulting thread will end cleanly if the returned [ScheduleHandle] is dropped.
     pub fn watch_thread(self, frequency: Duration) -> ScheduleHandle {
         let stop = Arc::new(AtomicBool::new(false));
         let my_stop = stop.clone();


### PR DESCRIPTION
This PR fixes a minor doc comment typo.